### PR TITLE
add auth_methods to SFTP

### DIFF
--- a/bin/check-sftp.rb
+++ b/bin/check-sftp.rb
@@ -146,6 +146,6 @@ class CheckSftp < Sensu::Plugin::Check::CLI
   end
 
   def sftp
-    @sftp ||= Net::SFTP.start(config[:host], config[:username], password: config[:password], timeout: config[:timeout], port: config[:port])
+    @sftp ||= Net::SFTP.start(config[:host], config[:username], password: config[:password], timeout: config[:timeout], port: config[:port],auth_methods:['publickey','password'])
   end
 end


### PR DESCRIPTION
Script fails when authenticating with a username/password. Defining auth_methods in the SFTP.start function fix's this.

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [x] Tests

- [x] Add the plugin to the README

- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatability Issues

